### PR TITLE
Add Google Keep integration and configurable grid layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ NEWS_Y = 340, no header bar
 
 - **Fonts**: Inter (fonts/ dir) → Futura (macOS) → Helvetica (macOS) → DejaVu (Linux)
 - **Colors**: inverted — BG=0 (black), FG=255 (white), GRAY=255, DIVIDER=80
-- FONT_HUGE=52bold, FONT_LARGE=28bold, FONT_MED=18bold, FONT_SMALL=17bold,
+- FONT_HUGE=52bold, FONT_VLARGE=42bold, FONT_LARGE=28bold, FONT_MED=18bold, FONT_SMALL=17bold,
   FONT_TINY=14bold, FONT_LABEL=12, FONT_HEADER=22bold
 - Section labels: FONT_LABEL gray at top of each cell (`_label()` helper)
 - No dividers between list items (removed for cleaner look)
@@ -129,6 +129,15 @@ cache:
 ```
 
 Cron runs `main.py` every 10 minutes + `@reboot`; each module decides independently.
+
+## Electricity module specifics (data/electricity.py)
+
+- Fetches from Caruna Plus API via pycaruna (username/password in config)
+- Uses `TimeSpan.MONTHLY` to get day-by-day data; data may lag 1–2 days behind today
+- Returns last 7 days of consumption as `daily_kwh`: `[{"date": "YYYY-MM-DD", "kwh": float}, ...]`
+- Cross-month fetch: if 7-day window spans two months, makes a second API call for the prior month
+- `yesterday_kwh` / `yesterday_date` are derived from the most recent entry in `daily_kwh`
+- Rendered with FONT_VLARGE (42px) value + bar chart (7 bars anchored to cell bottom)
 
 ## HSL module specifics (data/hsl.py)
 
@@ -170,7 +179,8 @@ Cron runs `main.py` every 10 minutes + `@reboot`; each module decides independen
 
 ## Known issues / TODO
 
-- [ ] Caruna (pycaruna) returning null kWh — likely Caruna API change, check pycaruna updates
+- [x] Caruna returning null kWh — resolved; now fetches 7-day daily history (`daily_kwh` list)
+- [ ] Consider adding forecast strip to weather cell
 - [ ] Consider adding forecast strip to weather cell
 - [ ] Pi Zero 2 W with headers (WH version) would avoid needing to solder headers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ source venv/bin/activate
 python main.py --preview           # full run, open PNG
 python main.py --no-cache --preview
 python main.py --only hsl --no-cache   # test single module
+python main.py --only keep --no-cache  # test Google Keep module
 ```
 
 ### Windows
@@ -30,6 +31,7 @@ cp config.example.yaml config.yaml   # then edit config.yaml with your credentia
 venv/Scripts/python main.py --preview           # full run, opens PNG in default viewer
 venv/Scripts/python main.py --no-cache --preview
 venv/Scripts/python main.py --only weather --no-cache   # test single module
+venv/Scripts/python main.py --only keep --no-cache      # test Google Keep module
 
 # For clean log output (suppresses Unicode encoding noise in cp1252 terminals)
 PYTHONIOENCODING=utf-8 venv/Scripts/python main.py --no-cache
@@ -69,6 +71,7 @@ data/
   evaka.py           – Espoo eVaka weak-login session API
   hsl.py             – HSL Digitransit v2 GraphQL
   news.py            – YLE RSS feed (no auth)
+  keep.py            – Google Keep notes via gkeepapi (app-specific password)
 
 display/
   simulator.py       – saves output/dashboard.png (macOS)
@@ -77,17 +80,39 @@ display/
 
 ## Layout (3 columns × 2 rows + full-width news strip)
 
+The 6 grid cells are configurable via `layout.grid` in `config.yaml`.
+The news strip is fixed at the bottom (always full-width).
+
 ```
 ┌──────────────────┬──────────────────┬──────────────────┐  ROW_H = 170px
-│  PÄIVÄKOTI       │  KALENTERI       │  SÄÄ + PVM/KELLO │
+│  layout[0][0]    │  layout[0][1]    │  layout[0][2]    │
 ├──────────────────┼──────────────────┼──────────────────┤  ROW_H = 170px
-│  SÄHKÖ           │  HSL             │  JÄTEHUOLTO      │
+│  layout[1][0]    │  layout[1][1]    │  layout[1][2]    │
 ├──────────────────┴──────────────────┴──────────────────┤  NEWS_H = 140px
 │  UUTISET  (full width, 2 items stacked)                │
 └────────────────────────────────────────────────────────┘
 COL_W ≈ 266px, COL2_X = 267, COL3_X = 534
 NEWS_Y = 340, no header bar
 ```
+
+Default layout (matches original hardcoded order):
+```yaml
+layout:
+  grid:
+    - [evaka, calendar, weather]
+    - [electricity, hsl, waste]
+```
+
+Available modules for grid cells: `weather`, `calendar`, `electricity`, `waste`, `hsl`, `evaka`, `keep`
+Use `~` (null) to leave a cell blank. An unknown or unconfigured-but-required module shows a placeholder.
+
+### Configurable layout internals (render.py)
+
+- `DEFAULT_LAYOUT` constant defines the fallback grid
+- `_DRAW_FUNCS` dict maps module name → draw function (e.g. `"evaka"` → `_draw_daycare`)
+- `render(data, layout, news, width, height)` iterates the grid and dispatches to draw functions
+- `_draw_placeholder()` is called for blank/unknown cells
+- `main.py` reads `layout.grid`, validates it, collects unique module names, and only fetches those
 
 ## Rendering conventions (render.py)
 
@@ -102,6 +127,7 @@ NEWS_Y = 340, no header bar
 - Arrows: use `->` not `→` (unicode arrows unreliable across fonts)
 - Text wrapping: `_wrap_text(draw, text, font, max_width)` — pixel-based, not char-based
 - Badge: `_badge(draw, x, y, text)` — black pill with white text (used in HSL)
+- `render()` signature: `render(data, layout, news, width, height)` — data is a dict keyed by module name
 
 ## Data module patterns
 
@@ -177,12 +203,33 @@ Cron runs `main.py` every 10 minutes + `@reboot`; each module decides independen
 - Returns top 3 items with title + description
 - Rendered full-width at bottom: 2 items stacked, description in FONT_LABEL
 
+## Google Keep module specifics (data/keep.py)
+
+- Uses `gkeepapi` (unofficial Python library for Google Keep sync API)
+- Auth: `keep.login(username, password)` — requires an **app-specific password**, not your main Google password
+  - Generate at: https://myaccount.google.com/apppasswords
+- Optional label filter: `keep.findLabel(label_name)` — degrades gracefully if label not found
+- Returns up to `max_notes` (default 5) notes, pinned notes sorted first:
+  ```python
+  {
+      "notes": [{"title": str, "snippet": str, "pinned": bool}, ...],
+      "label": str,
+      "fetched_at": str,
+      "_stale": bool   # optional
+  }
+  ```
+- Cache: `cache/keep.json`, TTL from `keep.ttl_minutes` (default 60 min)
+- On failure: returns stale cache if available, otherwise raises `DataFetchError`
+- Render: pinned notes get a filled-dot indicator; title in FONT_MED, snippet (up to 2 lines) in FONT_LABEL
+- Section label: `keep.label.upper()` if set, otherwise `"MUISTIINPANOT"`
+
 ## Known issues / TODO
 
 - [x] Caruna returning null kWh — resolved; now fetches 7-day daily history (`daily_kwh` list)
-- [ ] Consider adding forecast strip to weather cell
+- [x] Layout hardcoded — resolved; now configurable via `layout.grid` in config.yaml
 - [ ] Consider adding forecast strip to weather cell
 - [ ] Pi Zero 2 W with headers (WH version) would avoid needing to solder headers
+- [ ] gkeepapi token persistence — currently re-authenticates on every non-cached fetch; could cache the master token via `keep.getMasterToken()` / `keep.resume()`
 
 ## Git
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,28 +3,45 @@
 ## Project overview
 
 Home dashboard for Waveshare 7.5" e-ink display (800×480px, grayscale).
-Development on macOS (PNG simulation), deployed on Raspberry Pi 3 Model B.
+Development on macOS or Windows (PNG simulation), deployed on Raspberry Pi Zero 2 W.
 
 Hardware: Waveshare 7.5" e-Paper HAT V2 + Raspberry Pi Zero 2 W (wired, wall-mounted).
 
 ## Running
 
+### macOS
 ```bash
 cd /Users/sihvojuh/Personal/Projects/eInk
 source venv/bin/activate
 
-python main.py --preview           # full run, open PNG on macOS
+python main.py --preview           # full run, open PNG
 python main.py --no-cache --preview
 python main.py --only hsl --no-cache   # test single module
 ```
 
-Sync to Pi:
+### Windows
 ```bash
-./sync.sh   # rsync to pi@eink.local:~/eInk/ (excludes venv, cache, output, .git)
+# First-time setup
+python -m venv venv
+venv/Scripts/pip install -r requirements.txt
+cp config.example.yaml config.yaml   # then edit config.yaml with your credentials
+
+# Running (in bash/Git Bash terminal)
+venv/Scripts/python main.py --preview           # full run, opens PNG in default viewer
+venv/Scripts/python main.py --no-cache --preview
+venv/Scripts/python main.py --only weather --no-cache   # test single module
+
+# For clean log output (suppresses Unicode encoding noise in cp1252 terminals)
+PYTHONIOENCODING=utf-8 venv/Scripts/python main.py --no-cache
 ```
 
-Run on Pi:
+Note: Windows terminals using cp1252 encoding will show `--- Logging error ---` noise for
+the ✓/✗ log characters — this is cosmetic only. The PNG is still generated correctly.
+`PYTHONIOENCODING=utf-8` suppresses it.
+
+### Raspberry Pi (deploy)
 ```bash
+./sync.sh   # rsync to pi@eink.local:~/eInk/ (excludes venv, cache, output, .git)
 ssh pi@eink.local "cd ~/eInk && venv/bin/python main.py"
 ssh pi@eink.local "cd ~/eInk && venv/bin/python main.py --no-cache"
 ```
@@ -160,7 +177,5 @@ Cron runs `main.py` every 10 minutes + `@reboot`; each module decides independen
 ## Git
 
 Branch: main
-Repo: https://github.com/JuhaniS/eInk
-Last major commits:
-- "Refine layout, fonts, and config" — Inter fonts, 3-col layout, news strip, evaka cutoff fix
-- "Update README" — layout diagram, hardware info
+Repo: https://github.com/jaatuli/masterplan
+Upstream: https://github.com/JuhaniS/eInk

--- a/README.md
+++ b/README.md
@@ -39,16 +39,27 @@ A home dashboard for a Waveshare 7.5" e-ink display (800×480), running on a Ras
 | Daycare | Espoo eVaka (`/api/citizen/auth/weak-login`) | Username + password |
 | Transit | [HSL Digitransit v2 GraphQL](https://portal-api.digitransit.fi/) | API key |
 
-## Development setup (macOS)
+## Development setup
+
+Runs on macOS and Windows. Both use PNG simulation — no Raspberry Pi needed for development.
 
 ### 1. Clone and create virtualenv
 
+**macOS / Linux:**
 ```bash
 git clone <repo>
 cd eInk
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+**Windows (Git Bash or similar):**
+```bash
+git clone <repo>
+cd eInk
+python -m venv venv
+venv/Scripts/pip install -r requirements.txt
 ```
 
 ### 2. Configure
@@ -101,19 +112,26 @@ Register at [portal-api.digitransit.fi](https://portal-api.digitransit.fi/) and 
 
 ### 5. Run
 
+**macOS:**
 ```bash
-source venv/bin/activate
-
-# Full run, open preview on macOS
-python main.py --preview
-
-# Force data refresh (skip cache)
+python main.py --preview           # full run, opens PNG in Preview
 python main.py --no-cache --preview
-
-# Test a single module
-python main.py --only weather
-python main.py --only hsl --no-cache
+python main.py --only weather      # test single module
 ```
+
+**Windows:**
+```bash
+venv/Scripts/python main.py --preview           # full run, opens PNG in default viewer
+venv/Scripts/python main.py --no-cache --preview
+venv/Scripts/python main.py --only weather      # test single module
+
+# Optional: suppress Unicode log noise in cp1252 terminals
+PYTHONIOENCODING=utf-8 venv/Scripts/python main.py --no-cache
+```
+
+> **Windows note:** Windows terminals using cp1252 encoding show `--- Logging error ---` for the
+> ✓/✗ log characters — this is cosmetic only. The PNG is generated correctly regardless.
+> Set `PYTHONIOENCODING=utf-8` to suppress it.
 
 ## Raspberry Pi deployment
 
@@ -202,7 +220,7 @@ eInk/
 │   ├── evaka.py         # Espoo daycare (eVaka)
 │   └── hsl.py           # HSL Digitransit transit
 ├── display/
-│   ├── simulator.py     # PNG output for macOS development
+│   ├── simulator.py     # PNG output for macOS/Windows development
 │   └── epaper.py        # Waveshare 7.5" v2 driver (Raspberry Pi)
 ├── fonts/               # Optional: place Inter-Regular.ttf + Inter-Bold.ttf here
 ├── cache/               # JSON cache files (auto-generated)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -72,6 +72,27 @@ hsl:
   min_walk_bus: 3           # minimum minutes to walk to a bus/tram stop
   min_walk_rail: 15         # minimum minutes to walk to a train/metro station
 
+# ── Layout ───────────────────────────────────────────────────────────────────
+# Assign any data module to any of the 6 grid cells (3 columns × 2 rows).
+# Available modules: weather, calendar, electricity, waste, hsl, evaka, keep
+# Use ~ (null) to leave a cell blank.
+# The news strip is always rendered full-width at the bottom and is not configurable.
+layout:
+  grid:
+    - [evaka, calendar, weather]      # Row 1: left, center, right
+    - [electricity, hsl, waste]       # Row 2: left, center, right
+
+# ── Google Keep notes (optional) ─────────────────────────────────────────────
+# Requires a Google app-specific password — NOT your main Google password.
+# Generate one at: https://myaccount.google.com/apppasswords
+# Leave this section out entirely to disable the Keep panel.
+keep:
+  username: "your@gmail.com"
+  password: "xxxx xxxx xxxx xxxx"    # 16-char app-specific password
+  label: "dashboard"                  # optional: only show notes tagged with this label
+  max_notes: 5                        # max notes to display (default: 5)
+  ttl_minutes: 60                     # cache TTL in minutes (default: 60)
+
 # ── Display ───────────────────────────────────────────────────────────────────
 display:
   width: 800

--- a/data/electricity.py
+++ b/data/electricity.py
@@ -49,6 +49,13 @@ def fetch(config: dict, use_cache: bool = True) -> dict:
         )
 
     yesterday = date.today() - timedelta(days=1)
+    window_start = yesterday - timedelta(days=6)  # 7-day window
+
+    def _collect_entries(energy_list: list, into: dict):
+        for e in energy_list:
+            val = e.get("invoicedConsumption") or e.get("totalConsumption")
+            if val is not None:
+                into[e["timestamp"][:10]] = float(val)  # YYYY-MM-DD -> kWh
 
     try:
         from pycaruna import Authenticator, CarunaPlus, TimeSpan
@@ -73,17 +80,35 @@ def fetch(config: dict, use_cache: bool = True) -> dict:
             yesterday.year, yesterday.month, yesterday.day,
         )
 
-        # energy on lista diktejä (yksi per päivä kuukaudelta).
-        # Data voi tulla 1–2 päivän viiveellä – otetaan viimeisin päivä jolla on dataa.
-        # kentät: timestamp (ISO, esim. "2026-03-14T00:00:00+02:00"), totalConsumption, invoicedConsumption
+        # Collect all days with data from current month
+        all_data: dict[str, float] = {}
+        _collect_entries(energy, all_data)
+
+        # If 7-day window crosses a month boundary, fetch previous month too
+        if window_start.month != yesterday.month:
+            prev_energy = client.get_energy(
+                customer_id, asset_id,
+                TimeSpan.MONTHLY,
+                window_start.year, window_start.month, window_start.day,
+            )
+            _collect_entries(prev_energy, all_data)
+
+        # Build sorted list for the 7-day window
+        w_start_str = window_start.isoformat()
+        w_end_str   = yesterday.isoformat()
+        daily_kwh = [
+            {"date": d, "kwh": round(all_data[d], 2)}
+            for d in sorted(all_data)
+            if w_start_str <= d <= w_end_str
+        ]
+
+        # Most recent day with data (may lag 1-2 days behind yesterday)
         kwh = None
         actual_date = None
-        for entry in reversed(energy):
-            val = entry.get("invoicedConsumption") or entry.get("totalConsumption")
-            if val is not None:
-                kwh = float(val)
-                actual_date = entry.get("timestamp", "")[:10]  # YYYY-MM-DD
-                break
+        if daily_kwh:
+            latest = daily_kwh[-1]
+            kwh = latest["kwh"]
+            actual_date = latest["date"]
 
     except DataFetchError:
         raise
@@ -99,6 +124,7 @@ def fetch(config: dict, use_cache: bool = True) -> dict:
         "yesterday_date":    actual_date or yesterday.isoformat(),
         "cost_estimate_eur": None,
         "fetched_at":        datetime.now().isoformat(timespec="seconds"),
+        "daily_kwh":         daily_kwh,
     }
 
     kwh_price = caruna_cfg.get("kwh_price_eur")

--- a/data/keep.py
+++ b/data/keep.py
@@ -1,0 +1,114 @@
+"""
+keep.py – Fetches notes from Google Keep via gkeepapi.
+
+Config:
+  keep:
+    username: "email@gmail.com"
+    password: "app_specific_password"  # Google app-specific password (not your main password)
+    label: "dashboard"                 # optional: filter by label name
+    max_notes: 5                       # optional, default 5
+    ttl_minutes: 60                    # optional, default 60
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+CACHE_FILE  = Path("cache/keep.json")
+DEFAULT_TTL = 60
+DEFAULT_MAX = 5
+
+log = logging.getLogger(__name__)
+
+
+class DataFetchError(Exception):
+    pass
+
+
+def _cache_is_fresh(ttl_minutes: int) -> bool:
+    if not CACHE_FILE.exists():
+        return False
+    age = datetime.now().timestamp() - CACHE_FILE.stat().st_mtime
+    return age < ttl_minutes * 60
+
+
+def _load_cache() -> dict | None:
+    try:
+        return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _save_cache(data: dict):
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def fetch(config: dict, use_cache: bool = True) -> dict:
+    keep_cfg   = config.get("keep", {})
+    ttl        = int(keep_cfg.get("ttl_minutes", DEFAULT_TTL))
+    max_notes  = int(keep_cfg.get("max_notes", DEFAULT_MAX))
+    username   = keep_cfg.get("username")
+    password   = keep_cfg.get("password")
+    label_name = keep_cfg.get("label")  # may be None
+
+    if not username or not password:
+        raise DataFetchError("keep.username and keep.password are required in config")
+
+    if use_cache and _cache_is_fresh(ttl):
+        cached = _load_cache()
+        if cached:
+            return cached
+
+    try:
+        import gkeepapi  # imported here so missing library gives a clear error
+
+        keep = gkeepapi.Keep()
+        keep.login(username, password)
+
+        # Resolve label filter
+        target_label = None
+        if label_name:
+            target_label = keep.findLabel(label_name)
+            # findLabel returns None if no match — degrade gracefully to all notes
+
+        notes_gen = keep.find(
+            labels=[target_label] if target_label else None,
+            archived=False,
+            trashed=False,
+        )
+
+        notes = []
+        for node in notes_gen:
+            if len(notes) >= max_notes:
+                break
+            title   = (node.title or "").strip()
+            body    = (node.text  or "").strip()
+            snippet = body[:120]
+            notes.append({
+                "title":   title,
+                "snippet": snippet,
+                "pinned":  bool(node.pinned),
+            })
+
+        # Pinned notes first, preserve server order within each group
+        notes.sort(key=lambda n: not n["pinned"])
+
+    except Exception as e:
+        cached = _load_cache()
+        if cached:
+            cached["_stale"] = True
+            log.warning("keep fetch failed, using stale cache: %s", e)
+            return cached
+        raise DataFetchError(f"Google Keep fetch failed: {e}") from e
+
+    data = {
+        "notes":      notes,
+        "label":      label_name or "",
+        "fetched_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    _save_cache(data)
+    return data

--- a/display/simulator.py
+++ b/display/simulator.py
@@ -1,10 +1,11 @@
 import os
+import platform
 import subprocess
 from pathlib import Path
 
 
 class SimulatorDisplay:
-    """Mac-simulaatio: tallentaa kuvan PNG:nä ja avaa sen Preview-ohjelmalla."""
+    """Simulaatio: tallentaa kuvan PNG:nä ja avaa sen oletuskuvakatselijalla."""
 
     OUTPUT_PATH = Path("output/dashboard.png")
 
@@ -14,4 +15,10 @@ class SimulatorDisplay:
         print(f"Kuva tallennettu: {self.OUTPUT_PATH.resolve()}")
 
         if open_preview:
-            subprocess.Popen(["open", str(self.OUTPUT_PATH)])
+            system = platform.system()
+            if system == "Windows":
+                os.startfile(str(self.OUTPUT_PATH))
+            elif system == "Darwin":
+                subprocess.Popen(["open", str(self.OUTPUT_PATH)])
+            else:
+                subprocess.Popen(["xdg-open", str(self.OUTPUT_PATH)])

--- a/main.py
+++ b/main.py
@@ -69,6 +69,8 @@ def fetch_module(name: str, config: dict, use_cache: bool) -> "dict | None":
             from data.hsl import fetch
         elif name == "news":
             from data.news import fetch
+        elif name == "keep":
+            from data.keep import fetch
         else:
             log.error("Unknown module: %s", name)
             return None
@@ -98,7 +100,7 @@ def parse_args():
     )
     parser.add_argument(
         "--only",
-        choices=["weather", "electricity", "waste", "calendar", "evaka", "hsl", "news"],
+        choices=["weather", "electricity", "waste", "calendar", "evaka", "hsl", "news", "keep"],
         help="Run only one module (for testing)"
     )
     parser.add_argument(
@@ -130,36 +132,51 @@ def main():
         print(json.dumps(data, ensure_ascii=False, indent=2))
         return
 
-    # Fetch all modules independently
+    # Determine grid layout from config (falls back to default if absent/invalid)
+    from render import DEFAULT_LAYOUT
+
+    def _validate_grid(grid) -> bool:
+        return (
+            isinstance(grid, list) and len(grid) == 2
+            and all(isinstance(r, list) and len(r) == 3 for r in grid)
+        )
+
+    grid = config.get("layout", {}).get("grid", DEFAULT_LAYOUT)
+    if not _validate_grid(grid):
+        log.warning("Invalid layout.grid in config — using default layout")
+        grid = DEFAULT_LAYOUT
+
+    # Modules that require specific credentials to be configured
+    _requires_config: dict[str, tuple[str, str]] = {
+        "evaka": ("evaka", "username"),
+        "hsl":   ("hsl",   "api_key"),
+        "keep":  ("keep",  "username"),
+    }
+
+    # Collect unique module names from the grid (skip None/blank cells)
+    grid_modules: set[str] = {
+        cell for row in grid for cell in row if cell
+    }
+
+    # Fetch only the modules that appear in the layout
     log.info("Fetching data...")
-    weather     = fetch_module("weather",     config, use_cache)
-    electricity = fetch_module("electricity", config, use_cache)
-    waste       = fetch_module("waste",       config, use_cache)
-    calendar    = fetch_module("calendar",    config, use_cache)
+    data: dict = {}
+    for name in grid_modules:
+        req = _requires_config.get(name)
+        if req and not config.get(req[0], {}).get(req[1]):
+            data[name] = None
+            continue
+        data[name] = fetch_module(name, config, use_cache)
 
-    # eVaka – only fetch if configured
-    daycare = None
-    if config.get("evaka", {}).get("username"):
-        daycare = fetch_module("evaka", config, use_cache)
-
-    # HSL – only fetch if api_key is configured
-    hsl = None
-    if config.get("hsl", {}).get("api_key"):
-        hsl = fetch_module("hsl", config, use_cache)
-
-    # News – always fetch (uses public RSS, no credentials needed)
+    # News – always fetched (full-width strip, not part of the configurable grid)
     news = fetch_module("news", config, use_cache)
 
     # Render image
     log.info("Rendering image...")
     from render import render
     image = render(
-        weather=weather,
-        electricity=electricity,
-        waste=waste,
-        calendar=calendar,
-        daycare=daycare,
-        hsl=hsl,
+        data=data,
+        layout=grid,
         news=news,
         width=width,
         height=height,

--- a/render.py
+++ b/render.py
@@ -583,6 +583,85 @@ def _draw_waste(draw: ImageDraw.Draw, data: dict | None,
         cy += line_h
 
 
+# ── Keep notes ──────────────────────────────────────────────────────────────
+
+def _draw_keep(draw: ImageDraw.Draw, data: dict | None,
+               x: int, y: int, w: int, h: int):
+    """Renders Google Keep notes in a grid cell."""
+    label_text = "MUISTIINPANOT"
+    if data and data.get("label"):
+        label_text = data["label"].upper()
+    cy = _label(draw, x, y, label_text, stale=bool(data and data.get("_stale")))
+
+    if not data:
+        _text(draw, (x + PAD, cy), "Ei saatavilla", FONT_SMALL, fill=GRAY)
+        return
+
+    notes = data.get("notes", [])
+    if not notes:
+        _text(draw, (x + PAD, cy), "Ei muistiinpanoja", FONT_TINY, fill=GRAY)
+        return
+
+    title_h   = 22   # FONT_MED line height
+    snippet_h = 15   # FONT_LABEL line height
+    gap       = 8    # vertical gap between notes
+    max_w     = w - 2 * PAD
+
+    for note in notes:
+        if cy + title_h > y + h - PAD:
+            break
+
+        title   = note.get("title", "")
+        snippet = note.get("snippet", "")
+        pinned  = note.get("pinned", False)
+
+        title_x = x + PAD
+        if pinned:
+            dot_r = 3
+            dot_cy = cy + title_h // 2
+            draw.ellipse(
+                [title_x, dot_cy - dot_r, title_x + dot_r * 2, dot_cy + dot_r],
+                fill=FG,
+            )
+            title_x += dot_r * 2 + 6
+
+        title_max_w = x + w - PAD - title_x
+        title_lines = _wrap_text(draw, title, FONT_MED, title_max_w)
+        _text(draw, (title_x, cy), title_lines[0] if title_lines else title, FONT_MED)
+        cy += title_h
+
+        if snippet and cy + snippet_h <= y + h - PAD:
+            for line in _wrap_text(draw, snippet, FONT_LABEL, max_w)[:2]:
+                if cy + snippet_h > y + h - PAD:
+                    break
+                _text(draw, (x + PAD, cy), line, FONT_LABEL, fill=GRAY)
+                cy += snippet_h
+
+        cy += gap
+
+
+# ── Placeholder (unconfigured / missing module) ──────────────────────────────
+
+def _draw_placeholder(draw: ImageDraw.Draw, data: dict | None,
+                      x: int, y: int, w: int, h: int, name: str = ""):
+    """Empty cell shown when a module is unconfigured or its name is unknown."""
+    cy = _label(draw, x, y, name.upper() if name else "—")
+    _text(draw, (x + PAD, cy), "Ei saatavilla", FONT_SMALL, fill=GRAY)
+
+
+# ── Module → draw-function dispatch ─────────────────────────────────────────
+
+_DRAW_FUNCS: dict[str, object] = {
+    "weather":     _draw_weather,
+    "calendar":    _draw_calendar,
+    "electricity": _draw_electricity,
+    "hsl":         _draw_hsl,
+    "waste":       _draw_waste,
+    "evaka":       _draw_daycare,   # module name differs from function name
+    "keep":        _draw_keep,
+}
+
+
 # ── Header ───────────────────────────────────────────────────────────────────
 
 def _draw_header(draw: ImageDraw.Draw, width: int):
@@ -606,51 +685,86 @@ def _draw_header(draw: ImageDraw.Draw, width: int):
 
 # ── Main render function ─────────────────────────────────────────────────────
 
+#: Default 3-col × 2-row grid (matches original hardcoded layout)
+DEFAULT_LAYOUT: list[list[str | None]] = [
+    ["evaka",       "calendar", "weather"],
+    ["electricity", "hsl",      "waste"],
+]
+
+
 def render(
-    weather:     dict | None = None,
-    electricity: dict | None = None,
-    waste:       dict | None = None,
-    calendar:    dict | None = None,
-    daycare:     dict | None = None,
-    hsl:         dict | None = None,
-    news:        dict | None = None,
+    data:   "dict[str, dict | None] | None" = None,
+    layout: "list[list[str | None]] | None" = None,
+    news:   dict | None = None,
     width:  int = WIDTH,
     height: int = HEIGHT,
 ) -> Image.Image:
     """
     Renders the dashboard and returns a PIL Image (mode L, 800×480).
 
-    Layout — dark header + 3-column × 2-row grid:
+    Parameters
+    ----------
+    data   : mapping of module name → fetch() result dict (or None if unavailable).
+             e.g. {"weather": {...}, "evaka": {...}, "hsl": None, ...}
+    layout : 2×3 grid specifying which module occupies each cell.
+             Defaults to DEFAULT_LAYOUT if not provided.
+             Use None in a cell to leave it blank.
+             e.g. [["evaka", "calendar", "weather"],
+                   ["electricity", "hsl", "waste"]]
+    news   : news module data (always rendered full-width at the bottom).
+    width, height : image dimensions in pixels.
 
-      ┌──────────────────────────────────────────────────────────┐  HEADER (46px)
-      │  KOTINÄKYMÄ                              ke 19.3.2026   │
-      ├──────────────────┬──────────────────┬────────────────────┤
-      │  PÄIVÄKOTI       │  KALENTERI       │  SÄÄ              │  ROW 1 (217px)
-      ├──────────────────┼──────────────────┼────────────────────┤
-      │  UUTISET         │  HSL             │  JÄTEHUOLTO       │  ROW 2 (217px)
-      └──────────────────┴──────────────────┴────────────────────┘
-       COL_W ≈ 266 px each
+    Layout:
+
+      ┌──────────────────┬──────────────────┬──────────────────┐  ROW_H px
+      │  layout[0][0]    │  layout[0][1]    │  layout[0][2]    │
+      ├──────────────────┼──────────────────┼──────────────────┤  ROW_H px
+      │  layout[1][0]    │  layout[1][1]    │  layout[1][2]    │
+      ├──────────────────┴──────────────────┴──────────────────┤  NEWS_H px
+      │  UUTISET  (full width)                                  │
+      └────────────────────────────────────────────────────────┘
     """
+    if data is None:
+        data = {}
+    if layout is None:
+        layout = DEFAULT_LAYOUT
+
+    # Compute geometry from actual width/height
+    col_w  = (width - 2) // 3
+    col2_x = col_w + 1
+    col3_x = col_w * 2 + 2
+    row_h  = (height - NEWS_H) // 2
+    row2_y = row_h
+    news_y = row_h * 2
+
+    xs = [0, col2_x, col3_x]
+    ws = [col_w, col_w, width - col3_x]
+    ys = [0, row2_y]
+
     img  = Image.new("L", (width, height), BG)
     draw = ImageDraw.Draw(img)
 
-    # Grid lines — 3 columns × 2 rows + full-width news strip
-    _vertical_divider(draw, COL_W,       0, NEWS_Y)
-    _vertical_divider(draw, COL_W * 2 + 1, 0, NEWS_Y)
-    _divider(draw, 0, ROW2_Y, width)
-    _divider(draw, 0, NEWS_Y,  width)
+    # Grid dividers
+    _vertical_divider(draw, col_w,           0, news_y)
+    _vertical_divider(draw, col_w * 2 + 1,   0, news_y)
+    _divider(draw, 0, row2_y, width)
+    _divider(draw, 0, news_y,  width)
 
-    # Row 1: daycare | calendar | weather+datetime
-    _draw_daycare (draw, daycare,     0,      0,      COL_W,          ROW_H)
-    _draw_calendar(draw, calendar,    COL2_X, 0,      COL_W,          ROW_H)
-    _draw_weather (draw, weather,     COL3_X, 0,      width - COL3_X, ROW_H)
+    # Draw each cell according to the layout grid
+    for row_idx, row in enumerate(layout[:2]):
+        for col_idx, module_name in enumerate(row[:3]):
+            x = xs[col_idx]
+            y = ys[row_idx]
+            w = ws[col_idx]
+            draw_fn   = _DRAW_FUNCS.get(module_name) if module_name else None
+            cell_data = data.get(module_name) if module_name else None
+            if draw_fn:
+                draw_fn(draw, cell_data, x, y, w, row_h)
+            else:
+                _draw_placeholder(draw, cell_data, x, y, w, row_h,
+                                  name=module_name or "")
 
-    # Row 2: electricity | hsl | waste
-    _draw_electricity(draw, electricity, 0,      ROW2_Y, COL_W,          ROW_H)
-    _draw_hsl        (draw, hsl,         COL2_X, ROW2_Y, COL_W,          ROW_H)
-    _draw_waste      (draw, waste,       COL3_X, ROW2_Y, width - COL3_X, ROW_H)
-
-    # Row 3: full-width news strip
-    _draw_news(draw, news, 0, NEWS_Y, width, NEWS_H)
+    # News strip — always full-width at the bottom
+    _draw_news(draw, news, 0, news_y, width, NEWS_H)
 
     return img

--- a/render.py
+++ b/render.py
@@ -64,7 +64,8 @@ ROW2_Y = ROW_H                     # 170
 NEWS_Y = ROW_H * 2                 # 340
 
 # Fonts
-FONT_HUGE   = _load_font(52, bold=True)   # temperature, kWh value
+FONT_HUGE   = _load_font(52, bold=True)   # temperature
+FONT_VLARGE = _load_font(42, bold=True)   # electricity kWh value
 FONT_LARGE  = _load_font(28, bold=True)   # HSL departure times
 FONT_MED    = _load_font(18, bold=True)   # event titles, waste types
 FONT_SMALL  = _load_font(17, bold=True)   # detail rows
@@ -368,11 +369,11 @@ def _draw_electricity(draw: ImageDraw.Draw, data: dict | None,
     dstr = data.get("yesterday_date", "")
 
     kwh_str = f"{kwh:.1f}" if kwh is not None else "-"
-    _text(draw, (x + PAD, cy), kwh_str, FONT_HUGE)
+    _text(draw, (x + PAD, cy), kwh_str, FONT_VLARGE)
 
     # "kWh" unit next to the number
-    bbox = draw.textbbox((0, 0), kwh_str, font=FONT_HUGE)
-    _text(draw, (x + PAD + bbox[2] - bbox[0] + 6, cy + 32), "kWh", FONT_SMALL, fill=GRAY)
+    bbox = draw.textbbox((0, 0), kwh_str, font=FONT_VLARGE)
+    _text(draw, (x + PAD + bbox[2] - bbox[0] + 6, cy + 24), "kWh", FONT_SMALL, fill=GRAY)
 
     # Date label below
     if dstr:
@@ -388,7 +389,30 @@ def _draw_electricity(draw: ImageDraw.Draw, data: dict | None,
                 label = f"{data_date.day}.{data_date.month}. ({delta} pv sitten)"
         except ValueError:
             label = dstr
-        _text(draw, (x + PAD, cy + 62), label, FONT_TINY, fill=GRAY)
+        _text(draw, (x + PAD, cy + 50), label, FONT_TINY, fill=GRAY)
+
+    # 7-day bar chart
+    bars = data.get("daily_kwh", [])
+    if bars:
+        BAR_AREA_H  = 40   # max bar height in px
+        BAR_LABEL_H = 14   # height reserved for day-of-month labels
+        bar_bottom = y + h - PAD - BAR_LABEL_H
+        bar_top    = bar_bottom - BAR_AREA_H
+
+        n      = len(bars)
+        avail_w = w - 2 * PAD
+        gap    = 4
+        bar_w  = max(4, (avail_w - gap * (n - 1)) // n)
+
+        max_kwh = max(b["kwh"] for b in bars) or 1
+
+        for i, entry in enumerate(bars):
+            bx    = x + PAD + i * (bar_w + gap)
+            bh    = max(2, int((entry["kwh"] / max_kwh) * BAR_AREA_H))
+            draw.rectangle([bx, bar_bottom - bh, bx + bar_w, bar_bottom], fill=FG)
+            d = datetime.strptime(entry["date"], "%Y-%m-%d")
+            _text(draw, (bx + bar_w // 2, bar_bottom + 2), str(d.day),
+                  FONT_LABEL, fill=GRAY, anchor="mt")
 
 
 def _draw_calendar(draw: ImageDraw.Draw, data: dict | None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 requests
 icalendar
 pycaruna
+gkeepapi


### PR DESCRIPTION
## Summary

This PR adds Google Keep note integration to the dashboard and refactors the render pipeline to support a fully configurable grid layout. The dashboard can now display any module in any of the 6 grid cells (3×2), with a new `keep` module for fetching and displaying pinned notes from Google Keep.

## Key Changes

- **New Google Keep module** (`data/keep.py`):
  - Fetches notes from Google Keep via `gkeepapi` library
  - Supports label filtering and note pinning indicators
  - Implements caching with configurable TTL
  - Gracefully degrades to stale cache on fetch failure

- **Configurable grid layout**:
  - Introduced `DEFAULT_LAYOUT` constant (3×2 grid matching original hardcoded layout)
  - `render()` now accepts `data` dict and `layout` parameter instead of individual module arguments
  - Layout can be customized via `config.yaml` under `layout.grid`
  - Cells can be left blank using `null` values
  - Added `_DRAW_FUNCS` dispatch table mapping module names to render functions
  - Added `_draw_placeholder()` for unconfigured/unknown modules

- **Electricity module enhancements**:
  - Now returns 7-day daily consumption history as `daily_kwh` list
  - Handles cross-month fetches when 7-day window spans two calendar months
  - Renders with new `FONT_VLARGE` (42px) for kWh value
  - Added bar chart visualization (7 bars anchored to cell bottom with day-of-month labels)
  - Adjusted vertical spacing for new layout

- **Font additions**:
  - Added `FONT_VLARGE` (42px bold) for electricity kWh values
  - Separated temperature (FONT_HUGE) from kWh (FONT_VLARGE) for better visual hierarchy

- **Main pipeline refactoring** (`main.py`):
  - Fetches only modules that appear in the configured layout
  - Skips modules with missing required credentials (evaka, hsl, keep)
  - Validates layout grid structure with fallback to default
  - Passes unified `data` dict to render instead of individual parameters

- **Documentation updates**:
  - Added Windows development setup instructions
  - Updated CLAUDE.md with electricity module specifics and 7-day bar chart details
  - Added Keep module configuration examples to `config.example.yaml`
  - Updated README with cross-platform development guidance

- **Display simulator improvements**:
  - Cross-platform image viewer support (Windows: `os.startfile()`, macOS: `open`, Linux: `xdg-open`)

## Implementation Details

- Keep notes are sorted with pinned items first, preserving server order within each group
- Electricity bar chart scales dynamically based on max kWh value in the 7-day window
- Layout validation ensures grid is exactly 2 rows × 3 columns; invalid configs fall back to default
- Modules requiring credentials (evaka, hsl, keep) are only fetched if configured; others always attempt fetch
- News strip remains full-width at bottom and is not part of the configurable grid

https://claude.ai/code/session_01FW19u1zPHtNKTgM4xC6mQk