### PR TITLE
Handle recurring calendar events using recurring-ical-events

### DIFF
--- a/data/calendar.py
+++ b/data/calendar.py
@@ -39,12 +39,16 @@ def _save_cache(data: dict):
 
 
 def _parse_ical(content: bytes, cal_name: str, window_start: date, window_end: date) -> list[dict]:
-    """Parses iCal content and returns events within the time window."""
+    """Parses iCal content and returns events within the time window,
+    expanding recurring events (RRULE) into individual occurrences."""
     try:
         from icalendar import Calendar
-        from icalendar.cal import Todo  # noqa: F401 – for type checking
+        import recurring_ical_events
     except ImportError:
-        raise DataFetchError("icalendar is not installed. Run: pip install icalendar")
+        raise DataFetchError(
+            "icalendar / recurring-ical-events is not installed. "
+            "Run: pip install -r requirements.txt"
+        )
 
     try:
         cal = Calendar.from_ical(content)
@@ -53,10 +57,14 @@ def _parse_ical(content: bytes, cal_name: str, window_start: date, window_end: d
 
     events = []
 
-    for component in cal.walk():
-        if component.name != "VEVENT":
-            continue
+    # recurring_ical_events expands RRULEs and returns one component per
+    # occurrence within [window_start, window_end). The end is exclusive,
+    # so add one day to keep parity with the original inclusive comparison.
+    occurrences = recurring_ical_events.of(cal).between(
+        window_start, window_end + timedelta(days=1)
+    )
 
+    for component in occurrences:
         dtstart = component.get("DTSTART")
         if not dtstart:
             continue
@@ -72,9 +80,6 @@ def _parse_ical(content: bytes, cal_name: str, window_start: date, window_end: d
             event_date = start_val
             time_str   = None
             all_day    = True
-
-        if not (window_start <= event_date <= window_end):
-            continue
 
         # Parse end time for timed events so we can filter out past events
         end_iso: str | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pillow
 pyyaml
 requests
 icalendar
+recurring-ical-events
 pycaruna


### PR DESCRIPTION
## Summary
This PR adds support for expanding recurring calendar events (RRULE) into individual occurrences, improving the accuracy of calendar event parsing.

## Key Changes
- **Replaced manual event filtering with `recurring_ical_events` library**: The previous implementation used `cal.walk()` to iterate through all components and manually filtered events by date range. Now uses `recurring_ical_events.of(cal).between()` which automatically expands recurring events into individual occurrences within the specified time window.
- **Removed redundant date range check**: The manual date range validation (`if not (window_start <= event_date <= window_end)`) is no longer needed since the library handles this filtering.
- **Updated error messaging**: Changed the ImportError message to reference both required packages and direct users to install via `requirements.txt`.
- **Added dependency**: Added `recurring-ical-events` to requirements.txt.

## Implementation Details
- The `recurring_ical_events.between()` method uses an exclusive end date, so we add one day to `window_end` to maintain parity with the original inclusive date comparison behavior.
- Added clarifying comments explaining the behavior of the recurring events expansion and the date range handling.

https://claude.ai/code/session_014j4xGgq85NUW1RoY5AKuBH